### PR TITLE
Explicitly Shutdown the Prune Thread

### DIFF
--- a/Orderbook.h
+++ b/Orderbook.h
@@ -42,6 +42,7 @@ private:
     mutable std::mutex ordersMutex_;
     std::thread ordersPruneThread_;
     std::condition_variable shutdownConditionVariable_;
+    std::atomic<bool> shutdown_{ false };
 
     void PruneGoodForDayOrders();
 


### PR DESCRIPTION
Handles the case where we signal the condition variable before or after it is waited on.