### PR TITLE
Move Header Files into Seperate Folder & Add Market Order

### DIFF
--- a/Constants.h
+++ b/Constants.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <limits>
+
+#include "Usings.h"
+
+struct Constants
+{
+    static const Price InvalidPrice = std::numeric_limits<Price>::quiet_NaN();
+};

--- a/Order.h
+++ b/Order.h
@@ -7,6 +7,8 @@
 #include "OrderType.h"
 #include "Side.h"
 #include "Usings.h"
+#include "Constants.h"
+
 
 class Order
 {
@@ -18,6 +20,10 @@ public:
         , price_{ price }
         , initialQuantity_{ quantity }
         , remainingQuantity_{ quantity }
+    { }
+
+    Order(OrderId orderId, Side side, Quantity quantity)
+        : Order(OrderType::Market, orderId, side, Constants::InvalidPrice, quantity)
     { }
 
     OrderId GetOrderId() const { return orderId_; }
@@ -34,6 +40,14 @@ public:
             throw std::logic_error(std::format("Order ({}) cannot be filled for more than its remaining quantity.", GetOrderId()));
 
         remainingQuantity_ -= quantity;
+    }
+    void ToGoodTillCancel(Price price) 
+    { 
+        if (GetOrderType() != OrderType::Market)
+            throw std::logic_error(std::format("Order ({}) cannot have its price adjusted, only market orders can.", GetOrderId()));
+
+        price_ = price;
+        orderType_ = OrderType::GoodTillCancel;
     }
 
 private:

--- a/OrderType.h
+++ b/OrderType.h
@@ -6,4 +6,5 @@ enum class OrderType
 	FillAndKill,
 	FillOrKill,
 	GoodForDay,
+	Market,
 };

--- a/Orderbook.cpp
+++ b/Orderbook.cpp
@@ -274,6 +274,22 @@ Trades Orderbook::AddOrder(OrderPointer order)
 	if (orders_.contains(order->GetOrderId()))
 		return { };
 
+	if (order->GetOrderType() == OrderType::Market)
+	{
+		if (order->GetSide() == Side::Buy && !asks_.empty())
+		{
+			const auto& [worstAsk, _] = *asks_.rbegin();
+			order->ToGoodTillCancel(worstAsk);
+		}
+		else if (order->GetSide() == Side::Sell && !bids_.empty())
+		{
+			const auto& [worstBid, _] = *bids_.rbegin();
+			order->ToGoodTillCancel(worstBid);
+		}
+		else
+			return { };
+	}
+
 	if (order->GetOrderType() == OrderType::FillAndKill && !CanMatch(order->GetSide(), order->GetPrice()))
 		return { };
 
@@ -286,13 +302,13 @@ Trades Orderbook::AddOrder(OrderPointer order)
 	{
 		auto& orders = bids_[order->GetPrice()];
 		orders.push_back(order);
-		iterator = std::next(orders.begin(), orders.size() - 1);
+		iterator = std::prev(orders.end());
 	}
 	else
 	{
 		auto& orders = asks_[order->GetPrice()];
 		orders.push_back(order);
-		iterator = std::next(orders.begin(), orders.size() - 1);
+		iterator = std::prev(orders.end());
 	}
 
 	orders_.insert({ order->GetOrderId(), OrderEntry{ order, iterator } });

--- a/Orderbook.vcxproj
+++ b/Orderbook.vcxproj
@@ -133,6 +133,7 @@
     <ClCompile Include="Orderbook.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Constants.h" />
     <ClInclude Include="LevelInfo.h" />
     <ClInclude Include="Order.h" />
     <ClInclude Include="Orderbook.h" />

--- a/Orderbook.vcxproj.filters
+++ b/Orderbook.vcxproj.filters
@@ -18,5 +18,43 @@
     <ClCompile Include="Orderbook.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="LevelInfo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Order.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Orderbook.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="OrderbookLevelInfos.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="OrderModify.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="OrderType.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Side.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Trade.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="TradeInfo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Usings.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Constants.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Title. Should have done in two seperate commits, but whatever.

1. Move headers into the same folder, so the solution is cleaner.
2. Add Market OrderType support.
3. Use `std::prev` instead of `std::next` for shorter code.