### PR TITLE
Add FillAndKill & Market Order Type Tests

### DIFF
--- a/OrderbookTest/TestFiles/Match_FillAndKill.txt
+++ b/OrderbookTest/TestFiles/Match_FillAndKill.txt
@@ -1,0 +1,3 @@
+A B GoodTillCancel 100 10 1
+A S FillAndKill 100 10 2
+R 0 0 0

--- a/OrderbookTest/TestFiles/Match_Market.txt
+++ b/OrderbookTest/TestFiles/Match_Market.txt
@@ -1,0 +1,12 @@
+A B GoodTillCancel 100 10 1
+A B GoodTillCancel 101 10 2
+A B GoodTillCancel 102 10 3
+A B GoodTillCancel 103 10 4
+A B GoodTillCancel 104 10 5
+A B GoodTillCancel 105 10 6
+A B GoodTillCancel 106 10 7
+A B GoodTillCancel 107 10 8
+A B GoodTillCancel 108 10 9
+A B GoodTillCancel 109 10 10
+A S Market 0 101 11
+R 1 0 1

--- a/OrderbookTest/test.cpp
+++ b/OrderbookTest/test.cpp
@@ -272,8 +272,10 @@ TEST_P(OrderbookTestsFixture, OrderbookTestSuite)
 
 INSTANTIATE_TEST_CASE_P(Tests, OrderbookTestsFixture, googletest::ValuesIn({
     "Match_GoodTillCancel.txt",
+    "Match_FillAndKill.txt",
     "Match_FillOrKill_Hit.txt",
     "Match_FillOrKill_Miss.txt",
     "Cancel_Success.txt",
-    "Modify_Side.txt"
+    "Modify_Side.txt",
+    "Match_Market.txt"
 }));

--- a/OrderbookTest/test.cpp
+++ b/OrderbookTest/test.cpp
@@ -104,45 +104,6 @@ private:
         return columns;
     }
 
-    Information GetAddAction(const std::vector<std::string_view>& arguments) const
-    {
-        Side side = ParseSide(arguments[0]);
-        OrderType orderType = ParseOrderType(arguments[1]);
-        Price price = ParsePrice(arguments[2]);
-        Quantity quantity = ParseQuantity(arguments[3]);
-        OrderId orderId = ParseOrderId(arguments[4]);
-
-        return Information{ 
-            .type_ = ActionType::Add, 
-            .orderType_ = orderType,
-            .side_ = side,
-            .price_ = price, 
-            .quantity_ = quantity, 
-            .orderId_ = orderId, };
-    }
-
-    Information GetCancelAction(const std::vector<std::string_view>& arguments) const
-    {
-        return Information{
-            .type_ = ActionType::Cancel,
-            .orderId_ = ParseOrderId(arguments[1]) };
-    }
-
-    Information GetModifyAction(const std::vector<std::string_view>& arguments) const
-    {
-        OrderId orderId = ParseOrderId(arguments[1]);
-        Side side = ParseSide(arguments[2]);
-        Price price = ParsePrice(arguments[3]);
-        Quantity quantity = ParseQuantity(arguments[4]);
-
-        return Information{ 
-            .type_ = ActionType::Modify,
-            .side_ = side,
-            .price_ = price,
-            .quantity_ = quantity,
-            .orderId_ = orderId };
-    }
-
     Side ParseSide(const std::string_view& str) const
     {
         if (str == "B")

--- a/OrderbookTest/test.cpp
+++ b/OrderbookTest/test.cpp
@@ -219,6 +219,9 @@ public:
             }
             else
             {
+                if (!file.eof())
+                    throw std::logic_error("Result should only be specified at the end.");
+
                 Result result;
 
                 auto isValid = TryParseResult(line, result);


### PR DESCRIPTION
1. Force results to be at end of file. Just an extra precaution to ensure that all state-related information is read before the result of specified.
2. Add tests for FillAndKill and Market order types.
3. Remove unused code.